### PR TITLE
Move tutorial steps out of src/ directory.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,55 +17,51 @@ library(devtools)
 install_github('miriam-goldman/micro.glmm')
 ```
 
-### Move into src folder
-```
-cd src
-```
 ### run prep snps
 ```
-Rscript prep_snps_command_line.R  --species_id exp_species -v TRUE  -o "../example_output"
--i "../example_data/exp_species.snps_info.tsv"
--f "../example_data/exp_species.snps_freqs.tsv"
--d "../example_data/exp_species.snps_depth.tsv"
+Rscript src/prep_snps_command_line.R  --species_id exp_species -v TRUE  -o "example_output"
+-i "example_data/exp_species.snps_info.tsv"
+-f "example_data/exp_species.snps_freqs.tsv"
+-d "example_data/exp_species.snps_depth.tsv"
 -a 3 -m 5  -n 5   
  ```
 For easier copy
 ```
-Rscript prep_snps_command_line.R  --species_id exp_species -v TRUE  -o "../example_output" -i "../example_data/exp_species.snps_info.tsv" -f "../example_data/exp_species.snps_freqs.tsv" -d "../example_data/exp_species.snps_depth.tsv" -a 3 -m 5  -n 5   
+Rscript src/prep_snps_command_line.R  --species_id exp_species -v TRUE  -o "example_output" -i "example_data/exp_species.snps_info.tsv" -f "example_data/exp_species.snps_freqs.tsv" -d "example_data/exp_species.snps_depth.tsv" -a 3 -m 5  -n 5   
  ```
 ### run prep genes
 
 ```
-Rscript prep_genes_command_line.R --species_id exp_species -v TRUE -o "../example_output"
--c "../example_data/exp_species.genes_copynum.tsv"
--d "../example_data/exp_species.genes_depth.tsv"
--m 5 -n 5 --GRM ../example_output/exp_species.GRM.tsv --write_csv TRUE
+Rscript src/prep_genes_command_line.R --species_id exp_species -v TRUE -o "example_output"
+-c "example_data/exp_species.genes_copynum.tsv"
+-d "example_data/exp_species.genes_depth.tsv"
+-m 5 -n 5 --GRM example_output/exp_species.GRM.tsv --write_csv TRUE
  ```
 For easier copy
 ```
-Rscript prep_genes_command_line.R --species_id exp_species -v TRUE -o "../example_output" -c "../example_data/exp_species.genes_copynum.tsv" -d "../example_data/exp_species.genes_depth.tsv" -m 5 -n 5 --GRM ../example_output/exp_species.GRM.tsv --write_csv TRUE
+Rscript src/prep_genes_command_line.R --species_id exp_species -v TRUE -o "example_output" -c "example_data/exp_species.genes_copynum.tsv" -d "example_data/exp_species.genes_depth.tsv" -m 5 -n 5 --GRM example_output/exp_species.GRM.tsv --write_csv TRUE
  ```
 ### run population structure test
 
 ```
-Rscript pop_structure_test_command_line.R --species_id exp_species -v TRUE -o ../example_output
---GRM ../example_output/exp_species.GRM.tsv
---metadata ../example_data/exp_metadata.tsv
+Rscript src/pop_structure_test_command_line.R --species_id exp_species -v TRUE -o example_output
+--GRM example_output/exp_species.GRM.tsv
+--metadata example_data/exp_metadata.tsv
 --tau 1 --n_tau 10
 ```
 For easier copy
 ```
-Rscript pop_structure_test_command_line.R --species_id exp_species -v TRUE -o ../example_output --GRM ../example_output/exp_species.GRM.tsv --metadata ../example_data/exp_metadata.tsv --tau 1 --n_tau 10
+Rscript src/pop_structure_test_command_line.R --species_id exp_species -v TRUE -o example_output --GRM example_output/exp_species.GRM.tsv --metadata example_data/exp_metadata.tsv --tau 1 --n_tau 10
 ```
 ### Run Maker test
 
 ```
-Rscript marker_test_command_line.R --species_id exp_species -v TRUE
--o ../example_output
---Rdata ../example_output/exp_species.model_obj.Rdata
---copy_number ../example_output/exp_species.copynumber_data.csv
+Rscript src/marker_test_command_line.R --species_id exp_species -v TRUE
+-o example_output
+--Rdata example_output/exp_species.model_obj.Rdata
+--copy_number example_output/exp_species.copynumber_data.csv
 ```
 For easier copy
 ```
-Rscript marker_test_command_line.R --species_id exp_species -v TRUE -o ../example_output --Rdata ../example_output/exp_species.model_obj.Rdata --copy_number ../example_output/exp_species.copynumber_data.csv
+Rscript src/marker_test_command_line.R --species_id exp_species -v TRUE -o example_output --Rdata example_output/exp_species.model_obj.Rdata --copy_number example_output/exp_species.copynumber_data.csv
 ```


### PR DESCRIPTION
Changes all paths to work from git repository root. This requires that the path to the scripts themselves be changed, but also drops a bunch of '../' prefixes for all of the data files.